### PR TITLE
Sparse matrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,10 @@ Package: solitude
 Type: Package
 Title: An Implementation of Isolation Forest
 Version: 1.1.2
-Authors@R: person("Komala Sheshachala", "Srikanth", email = "sri.teach@gmail.com", role = c("aut", "cre"))
+Authors@R: c(
+    person("Komala Sheshachala", "Srikanth", email = "sri.teach@gmail.com", role = c("aut", "cre"),
+    person("David", "Zimmermann", email = "david_j_zimmermann@hotmail.com", role = "ctb")
+    )
 Description: Isolation forest is anomaly detection method introduced by the paper Isolation based Anomaly Detection (Liu, Ting and Zhou <doi:10.1145/2133360.2133363>).
 URL: https://github.com/talegari/solitude
 BugReports: https://github.com/talegari/solitude/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: solitude
 Type: Package
 Title: An Implementation of Isolation Forest
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: person("Komala Sheshachala", "Srikanth", email = "sri.teach@gmail.com", role = c("aut", "cre"))
 Description: Isolation forest is anomaly detection method introduced by the paper Isolation based Anomaly Detection (Liu, Ting and Zhou <doi:10.1145/2133360.2133363>).
 URL: https://github.com/talegari/solitude
@@ -16,7 +16,7 @@ Imports:
 Depends:
     R (>= 3.5.0),
 Suggests:
-    mvoutlier (>= 2.0.9),
+    mvoutlier (>= 2.0.9), Matrix
 License: GPL-3
 Encoding: UTF-8
 RoxygenNote: 7.1.1

--- a/man/isolationForest.Rd
+++ b/man/isolationForest.Rd
@@ -41,7 +41,7 @@
 
   }
 
-  \code{$fit()} fits a isolation forest for the given dataframe, computes
+  \code{$fit()} fits a isolation forest for the given dataframe or sparse matrix, computes
   depths of terminal nodes of each tree and stores the anomaly scores and
   average depth values in \code{$scores} object as a data.table
 


### PR DESCRIPTION
Fixes #12. I.e., adds Sparse Matrix Support to solitude.

Notes:
- for sparse matrices, checks for duplicates are dropped (its more complicated to check duplicates in sparse matrices than it seems, apparently).
- as ranger accesses the data differently, we get slightly different results than when using a data.frame representation.

Test with this code:

```r
library(solitude)
library(Matrix)

data("humus", package = "mvoutlier")
columns_required = setdiff(colnames(humus)
                           , c("Cond", "ID", "XCOO", "YCOO", "LOI")
)
humus2 = humus[ , columns_required]

# sparse matrices wouldnt be too interesting in this case, but showcases the issue
humus_sp <- Matrix(as.matrix(humus2), sparse = TRUE)

set.seed(1)
index = sample(ceiling(nrow(humus_sp) * 0.5))
# initiate an isolation forest
iso = isolationForest$new(sample_size = length(index))
iso$fit(dataset = humus_sp[index, ])
iso$predict(humus_sp[index, ]) # scores for train data
iso$predict(humus_sp[-index, ]) # scores for new data (50% sample)
```